### PR TITLE
update doc

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,23 @@ This file contains more detailed instructions on what's required when updating
 an application between one release version of the gem to the next. It's intended
 as more in-depth accompaniment to the notes in `CHANGELOG.md` for each version.
 
+## Bump shopify_api from 9.0 to 12.3, shopify_app from 12.0.7 to 21.3
+
+The shopify_api and shopify_app both have break change, please see [ shopify_api reademe](https://github.com/Shopify/shopify-api-ruby#breaking-change-notice-for-version-1000) [shopify_app upgrading](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md)
+
+Upgrade to Ruby 2.7.7.
+
+For security reason, you can disable the auto login feature via configuration in `config/initializers/disco_app.rb`.
+```
+DiscoApp.configure do |config|
+  ...
+
+  config.disable_auto_login = true
+
+  ...
+end
+```
+
 
 ## Upgrading from 0.18.6 to 0.19.0
 No changes required.


### PR DESCRIPTION
update doc

### Description
## Bump shopify_api from 9.0 to 12.3, shopify_app from 12.0.7 to 21.3

The shopify_api and shopify_app both have break change, please see [ shopify_api reademe](https://github.com/Shopify/shopify-api-ruby#breaking-change-notice-for-version-1000) [shopify_app upgrading](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md)

Upgrade to Ruby 2.7.7.

For security reason, you can disable the auto login feature via configuration in `config/initializers/disco_app.rb`.
```
DiscoApp.configure do |config|
  ...
  config.disable_auto_login = true
  ...
end
```

### Notes
* A bulleted list of any secondary information that you feel would be useful to the reviewer.
* Gotchas, new dependencies, unusual data migrations, etc., would all live here.

### Checklist

- [ ] Updated README and any other relevant documentation.
- [ ] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [ ] Ensured that Rubocop and friends are happy.
- [ ] Checked that this PR is referencing the correct base.
- [ ] Logged all time in Clockify.
